### PR TITLE
HTN dashboard: Overdue patients reports

### DIFF
--- a/css/template.css
+++ b/css/template.css
@@ -397,12 +397,6 @@ main {
     justify-content: flex-start;
   }
 
-  .overdue-min-height {
-    @media screen and (min-width: 1200px) {
-      min-height: 120px;
-    }
-  }
-
   .chart {
     height: 260px;
     margin: -8px;
@@ -437,7 +431,7 @@ main {
 
     & .detail p {
       font-size: 0.9rem;
-      margin: 0 0 1rem 0;
+      margin: 0.2rem 0;
     }
   }
 
@@ -914,11 +908,11 @@ table {
   color: #e77215;
 }
 
-.overdue-contacted {
+.overdue-called {
   color: #edbe00;
 }
 
-.overdue-contacted-denominator {
+.overdue-called-denominator {
   color: rgb(214, 159, 6);
 }
 

--- a/css/template.css
+++ b/css/template.css
@@ -915,7 +915,7 @@ table {
 }
 
 .overdue-contacted {
-  color: #f6ac2a;
+  color: #edbe00;
 }
 
 .overdue-contacted-denominator {

--- a/css/template.css
+++ b/css/template.css
@@ -211,16 +211,16 @@ hr {
 main {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 12px;
   width: 100%;
   max-width: 1600px;
   margin: auto;
-  padding: 0 24px 16px;
+  padding: 0 16px 16px;
 
   .columns-2,
   .columns-3 {
     display: grid;
-    grid-gap: 24px;
+    gap: 12px;
     grid-template-columns: minmax(0, 1fr);
     grid-auto-rows: auto;
   }
@@ -228,6 +228,8 @@ main {
 
 @media screen and (min-width: 880px) {
   main {
+    padding: 0 24px 16px;
+
     .columns-2,
     .columns-3 {
       flex: 0 0 50%;
@@ -391,6 +393,16 @@ main {
     border: none;
   }
 
+  &.normal-flow {
+    justify-content: flex-start;
+  }
+
+  .overdue-min-height {
+    @media screen and (min-width: 1200px) {
+      min-height: 120px;
+    }
+  }
+
   .chart {
     height: 260px;
     margin: -8px;
@@ -426,6 +438,29 @@ main {
     & .detail p {
       font-size: 0.9rem;
       margin: 0 0 1rem 0;
+    }
+  }
+
+  .extra {
+    margin-top: 32px;
+
+    & p {
+      margin: 8px 0;
+      font-size: 0.9rem;
+      & span {
+        font-weight: 800;
+      }
+    }
+
+    .agreed {
+      color: rgb(3, 155, 64);
+    }
+
+    .remind {
+      color: rgb(228, 151, 20);
+    }
+    .removed {
+      color: rgb(211, 23, 64);
     }
   }
 }
@@ -801,6 +836,10 @@ table {
   font-weight: 700;
 }
 
+.italic {
+  font-style: italic;
+}
+
 .text-grey {
   color: #888;
 }
@@ -869,6 +908,22 @@ table {
 }
 .step-three-drugs {
   background: #18d6a8;
+}
+
+.overdue {
+  color: #e77215;
+}
+
+.overdue-contacted {
+  color: #f6ac2a;
+}
+
+.overdue-contacted-denominator {
+  color: rgb(214, 159, 6);
+}
+
+.overdue-returned {
+  color: #5300e0;
 }
 
 /* Display options */

--- a/index.html
+++ b/index.html
@@ -5601,8 +5601,8 @@
               <div class="info-hover-text">
                 <p>
                   <span>Numerator:</span> Patients that are overdue on the 1st
-                  of the month. Excludes patients marked 'Remove from overdue
-                  list' (647).
+                  of the month. Patients marked 'Removed from list' are excluded
+                  (647).
                 </p>
                 <p>
                   <span>Denominator:</span> Patients under care. Dead patients
@@ -5651,8 +5651,8 @@
                 </p>
                 <p>
                   <span>Denominator:</span> Patients that are overdue on the 1st
-                  of the month. Excludes patients marked 'Remove from overdue
-                  list' (647).
+                  of the month. Patients marked 'Remove from list' are excluded
+                  (647).
                 </p>
               </div>
             </div>
@@ -5694,7 +5694,7 @@
                 </p>
                 <p class="italic">
                   Note: For patients contacted multiple times during the month,
-                  only the first contact is counted.
+                  it is 15 days from the first contact.
                 </p>
                 <p>
                   <span>Denominator:</span> Unique overdue patients contacted
@@ -5716,8 +5716,9 @@
                   <p class="text-grey">
                     of
                     <span class="overdue-contacted-denominator"
-                      >1,176 patients contacted in Jul-2024</span
-                    >
+                      >1,176 overdue patients contacted
+                    </span>
+                    in Jul-2024
                   </p>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -5592,7 +5592,143 @@
         </div>
       </div>
 
-      <h2 class="columns-header spacer">3. Inventory indicators</h2>
+      <h2 class="columns-header spacer">3. Overdue patients</h2>
+      <div class="columns-3">
+        <div class="card normal-flow">
+          <div class="heading overdue-min-height">
+            <h3>Overdue patients</h3>
+            <div class="info">
+              <div class="info-hover-text">
+                <p>
+                  <span>Numerator:</span> Patients that are overdue on the 1st
+                  of the month. Excludes patients marked 'Remove from overdue
+                  list' (647).
+                </p>
+                <p>
+                  <span>Denominator:</span> Patients under care. Dead patients
+                  (205) and 12 months lost to follow-up (1,562) are excluded.
+                </p>
+                <p>
+                  <span>Overdue patient:</span> Patient with a scheduled visit
+                  date which has passed with no visit.
+                </p>
+              </div>
+            </div>
+            <p>Patients that are overdue at the start of the month.</p>
+          </div>
+          <div class="body">
+            <div class="figures">
+              <div>
+                <p class="large-num overdue">26%</p>
+                <div class="detail">
+                  <p>2,800 patients were overdue at the start of Jul-2024</p>
+                  <p class="text-grey">
+                    of
+                    <span class="under-care">10,800 patients under care</span>
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div class="chart">
+              <canvas id="overdue"></canvas>
+            </div>
+          </div>
+        </div>
+
+        <div class="card normal-flow">
+          <div class="heading overdue-min-height">
+            <h3>Overdue patients contacted</h3>
+            <div class="info">
+              <div class="info-hover-text">
+                <p>
+                  <span>Numerator:</span> Unique overdue patients contacted
+                  during the month.
+                </p>
+                <p class="italic">
+                  Note: This number includes patients who became overdue during
+                  the month and were contacted. These patients are not part of
+                  the denominator.
+                </p>
+                <p>
+                  <span>Denominator:</span> Patients that are overdue on the 1st
+                  of the month. Excludes patients marked 'Remove from overdue
+                  list' (647).
+                </p>
+              </div>
+            </div>
+            <p>Overdue patients contacted during the month.</p>
+          </div>
+          <div class="body">
+            <div class="figures">
+              <p class="large-num overdue-contacted">42%</p>
+              <div class="detail">
+                <p>1,176 patients contacted in Jul-2024</p>
+                <p class="text-grey">
+                  of
+                  <span class="overdue">2,800 overdue patients</span>
+                </p>
+              </div>
+            </div>
+            <div class="chart">
+              <canvas id="overdueContacted"></canvas>
+            </div>
+            <div class="extra">
+              <p><span class="agreed">47%</span> (552) agreed to visit</p>
+              <p><span class="remind">28%</span> (329) to be contacted later</p>
+              <p>
+                <span class="removed">25%</span> (294) removed from contact list
+              </p>
+              <p class="text-grey">of 1,176 patients contacted in Jul-2024</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="card normal-flow">
+          <div class="heading overdue-min-height">
+            <h3>Contacted overdue patients that returned to care</h3>
+            <div class="info">
+              <div class="info-hover-text">
+                <p>
+                  <span>Numerator:</span> Patients that returned to care within
+                  15 days of their first contact.
+                </p>
+                <p class="italic">
+                  Note: For patients contacted multiple times during the month,
+                  only the first contact is counted.
+                </p>
+                <p>
+                  <span>Denominator:</span> Unique overdue patients contacted
+                  during the month.
+                </p>
+              </div>
+            </div>
+            <p>
+              Overdue patients that returned to care within 15 days of being
+              contacted.
+            </p>
+          </div>
+          <div class="body">
+            <div class="figures">
+              <div>
+                <p class="large-num overdue-returned">58%</p>
+                <div class="detail">
+                  <p>682 patients returned to care within 15 days</p>
+                  <p class="text-grey">
+                    of
+                    <span class="overdue-contacted-denominator"
+                      >1,176 patients contacted in Jul-2024</span
+                    >
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div class="chart">
+              <canvas id="overdueReturned"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
+      <h2 class="columns-header spacer">4. Inventory indicators</h2>
 
       <div class="columns-3">
         <div class="card">

--- a/index.html
+++ b/index.html
@@ -5646,7 +5646,7 @@
                 </p>
                 <p class="italic">
                   Note: This number includes patients who became overdue during
-                  the month and were contacted. These patients are not part of
+                  the month and were contacted. These patients may not part of
                   the denominator.
                 </p>
                 <p>

--- a/index.html
+++ b/index.html
@@ -5646,8 +5646,8 @@
                 </p>
                 <p class="italic">
                   Note: This number includes patients who became overdue during
-                  the month and were contacted. These patients may not part of
-                  the denominator.
+                  the month and were contacted. These patients may not be part
+                  of the denominator.
                 </p>
                 <p>
                   <span>Denominator:</span> Patients that are overdue on the 1st

--- a/index.html
+++ b/index.html
@@ -5595,14 +5595,14 @@
       <h2 class="columns-header spacer">3. Overdue patients</h2>
       <div class="columns-3">
         <div class="card normal-flow">
-          <div class="heading overdue-min-height">
+          <div class="heading">
             <h3>Overdue patients</h3>
             <div class="info">
               <div class="info-hover-text">
                 <p>
                   <span>Numerator:</span> Patients that are overdue on the 1st
-                  of the month. Patients marked 'Removed from list' are excluded
-                  (647).
+                  of the month. Patients marked 'Removed from list' (647) and
+                  patients with no phone number (241) are excluded.
                 </p>
                 <p>
                   <span>Denominator:</span> Patients under care. Dead patients
@@ -5636,33 +5636,33 @@
         </div>
 
         <div class="card normal-flow">
-          <div class="heading overdue-min-height">
-            <h3>Overdue patients contacted</h3>
+          <div class="heading">
+            <h3>Overdue patients called</h3>
             <div class="info">
               <div class="info-hover-text">
                 <p>
-                  <span>Numerator:</span> Unique overdue patients contacted
-                  during the month.
+                  <span>Numerator:</span> Unique overdue patients called during
+                  the month.
                 </p>
                 <p class="italic">
                   Note: This number includes patients who became overdue during
-                  the month and were contacted. These patients may not be part
-                  of the denominator.
+                  the month and were called. These patients may not be part of
+                  the denominator.
                 </p>
                 <p>
                   <span>Denominator:</span> Patients that are overdue on the 1st
-                  of the month. Patients marked 'Remove from list' are excluded
-                  (647).
+                  of the month. Patients marked 'Removed from list' (647) and
+                  patients with no phone number (241) are excluded.
                 </p>
               </div>
             </div>
-            <p>Overdue patients contacted during the month.</p>
+            <p>Patients called during the month.</p>
           </div>
           <div class="body">
             <div class="figures">
-              <p class="large-num overdue-contacted">42%</p>
+              <p class="large-num overdue-called">42%</p>
               <div class="detail">
-                <p>1,176 patients contacted in Jul-2024</p>
+                <p>1,176 patients called in Jul-2024</p>
                 <p class="text-grey">
                   of
                   <span class="overdue">2,800 overdue patients</span>
@@ -5670,42 +5670,36 @@
               </div>
             </div>
             <div class="chart">
-              <canvas id="overdueContacted"></canvas>
+              <canvas id="overdueCalled"></canvas>
             </div>
             <div class="extra">
               <p><span class="agreed">47%</span> (552) agreed to visit</p>
-              <p><span class="remind">28%</span> (329) to be contacted later</p>
-              <p>
-                <span class="removed">25%</span> (294) removed from contact list
-              </p>
-              <p class="text-grey">of 1,176 patients contacted in Jul-2024</p>
+              <p><span class="remind">28%</span> (329) to be called later</p>
+              <p><span class="removed">25%</span> (294) removed from list</p>
             </div>
           </div>
         </div>
 
         <div class="card normal-flow">
-          <div class="heading overdue-min-height">
-            <h3>Contacted overdue patients that returned to care</h3>
+          <div class="heading">
+            <h3>Overdue patients that returned to care</h3>
             <div class="info">
               <div class="info-hover-text">
                 <p>
                   <span>Numerator:</span> Patients that returned to care within
-                  15 days of their first contact.
+                  15 days of their first call.
                 </p>
                 <p class="italic">
-                  Note: For patients contacted multiple times during the month,
-                  15 days begins from the first contact.
+                  Note: For patients called multiple times during the month, 15
+                  days begins from the first call.
                 </p>
                 <p>
-                  <span>Denominator:</span> Unique overdue patients contacted
+                  <span>Denominator:</span> Unique overdue patients called
                   during the month.
                 </p>
               </div>
             </div>
-            <p>
-              Overdue patients that returned to care within 15 days of being
-              contacted.
-            </p>
+            <p>Patients that returned to care within 15 days of call.</p>
           </div>
           <div class="body">
             <div class="figures">
@@ -5715,8 +5709,8 @@
                   <p>682 patients returned to care within 15 days</p>
                   <p class="text-grey">
                     of
-                    <span class="overdue-contacted-denominator"
-                      >1,176 overdue patients contacted
+                    <span class="overdue-called-denominator"
+                      >1,176 overdue patients called
                     </span>
                     in Jul-2024
                   </p>
@@ -6651,11 +6645,11 @@
 
           <span class="nav-section">Overdue</span>
           <a href="#note-bp-overdue" class="nav-jump-links">Overdue patients</a>
-          <a href="#note-bp-overdue-contacted" class="nav-jump-links"
-            >Overdue patients contacted</a
+          <a href="#note-bp-overdue-called" class="nav-jump-links"
+            >Overdue patients called</a
           >
-          <a href="#note-bp-overdue-contacted-returned" class="nav-jump-links"
-            >Overdue patients contacted that returned to care</a
+          <a href="#note-bp-overdue-called-returned" class="nav-jump-links"
+            >Overdue that returned to care</a
           >
 
           <span class="nav-section">Stock</span>
@@ -7099,13 +7093,13 @@
             <div class="notes-note" id="bp-screening">
               <h5>Overdue patients</h5>
               <p>
-                Overdue patient reports allows provides facility staff
-                visibility on how many patients did not attend their scheduled
-                visit and the effectiveness of patient out reach systems.
-              </p>
-              <p>
                 Getting patients to attend for regular care is a major challenge
                 for hypertension control programs.
+              </p>
+              <p>
+                Overdue patients reports provide facility staff visibility on
+                how many patients did not attend their scheduled visit and the
+                effectiveness of patient outreach systems.
               </p>
             </div>
             <div class="notes-details">
@@ -7135,8 +7129,8 @@
                 <h6>Numerator</h6>
                 <p>
                   The number of <i>Overdue patients</i> on the 1st of the month,
-                  excluding patients that were previously contacted and marked
-                  'Remove from overdue list'.
+                  patients that were previously called and marked 'Remove from
+                  overdue list' and patients with no phone number are excluded.
                 </p>
 
                 <h6>Denominator</h6>
@@ -7148,40 +7142,45 @@
             </div>
           </div>
           <div class="notes-section">
-            <div class="notes-note" id="note-bp-overdue-contacted">
-              <h6>Overdue patients contacted</h6>
+            <div class="notes-note" id="note-bp-overdue-called">
+              <h6>Overdue patients called</h6>
               <p>
-                The percentage of overdue patients that were contacted during
-                the month.
+                The percentage of overdue patients that were called during the
+                month.
+              </p>
+              <p>
+                <b>Note:</b> The numerator is not a subset of the denominator
+                and as a result may exceed 100%. The value shown is capped at
+                100%.
               </p>
             </div>
             <div class="notes-details">
               <blockquote>
                 <h6>Numerator</h6>
                 <p>
-                  The number of unique <i>Overdue patients contacted</i> during
-                  the month.
+                  The number of unique <i>Overdue patients called</i> during the
+                  month.
                 </p>
                 <p>
                   <b>Note:</b> This number includes patients that became overdue
-                  during the month and were contacted, these patients may not be
+                  during the month and were called, these patients may not be
                   counted in the denominator.
                 </p>
                 <h6>Denominator</h6>
                 <p>
                   The number of <i>Overdue patients</i> on the 1st of the month,
-                  excluding patients that were previously contacted and marked
-                  'Remove from overdue list'.
+                  patients that were previously called and marked 'Remove from
+                  overdue list' and patients with no phone number are excluded.
                 </p>
               </blockquote>
             </div>
           </div>
           <div class="notes-section">
-            <div class="notes-note" id="note-bp-overdue-contacted-returned">
-              <h6>Overdue patients contacted that returned to care</h6>
+            <div class="notes-note" id="note-bp-overdue-called-returned">
+              <h6>Overdue patients called that returned to care</h6>
               <p>
-                The percentage of overdue patients that were contacted during
-                the month and returned to care within 15 days.
+                The percentage of overdue patients that were called during the
+                month and returned to care within 15 days.
               </p>
             </div>
             <div class="notes-details">
@@ -7189,17 +7188,17 @@
                 <h6>Numerator</h6>
                 <p>
                   The number of overdue patients that returned to care within 15
-                  days of their first contact.
+                  days of their first call.
                 </p>
                 <p>
-                  <b>Note:</b> For patients contacted multiple times during a
-                  month, 15 days begins from the date the patient was first
-                  contacted during a month.
+                  <b>Note:</b> For patients called multiple times during the
+                  month, 15 days begins from the date of the first call during
+                  the month.
                 </p>
                 <h6>Denominator</h6>
                 <p>
-                  The number of unique <i>Overdue patients contacted</i> during
-                  the month.
+                  The number of unique <i>Overdue patients called</i> during the
+                  month.
                 </p>
               </blockquote>
             </div>

--- a/index.html
+++ b/index.html
@@ -5694,7 +5694,7 @@
                 </p>
                 <p class="italic">
                   Note: For patients contacted multiple times during the month,
-                  it is 15 days from the first contact.
+                  15 days begins from the first contact.
                 </p>
                 <p>
                   <span>Denominator:</span> Unique overdue patients contacted
@@ -6649,6 +6649,15 @@
           <span class="nav-section">Cohorts</span>
           <a href="#note-bp-cohorts" class="nav-jump-links">Cohort reports</a>
 
+          <span class="nav-section">Overdue</span>
+          <a href="#note-bp-overdue" class="nav-jump-links">Overdue patients</a>
+          <a href="#note-bp-overdue-contacted" class="nav-jump-links"
+            >Overdue patients contacted</a
+          >
+          <a href="#note-bp-overdue-contacted-returned" class="nav-jump-links"
+            >Overdue patients contacted that returned to care</a
+          >
+
           <span class="nav-section">Stock</span>
           <a href="#note-bp-drug-stock" class="nav-jump-links"
             >Anti-hypertensive drug stock</a
@@ -7081,6 +7090,116 @@
                 <p>
                   <i>Adult OPD patients</i> with a blood pressure measure taken
                   in a month
+                </p>
+              </blockquote>
+            </div>
+          </div>
+
+          <div class="notes-section">
+            <div class="notes-note" id="bp-screening">
+              <h5>Overdue patients</h5>
+              <p>
+                Overdue patient reports allows provides facility staff
+                visibility on how many patients did not attend their scheduled
+                visit and the effectiveness of patient out reach systems.
+              </p>
+              <p>
+                Getting patients to attend for regular care is a major challenge
+                for hypertension control programs.
+              </p>
+            </div>
+            <div class="notes-details">
+              <blockquote>
+                <h6>Overdue patient</h6>
+                <p>
+                  A patient with a scheduled visit date that has passed with no
+                  visit.
+                </p>
+              </blockquote>
+            </div>
+          </div>
+          <div class="notes-section">
+            <div class="notes-note" id="note-bp-overdue">
+              <h6>Overdue patients</h6>
+              <p>
+                The percentage of patients that are overdue on the first of the
+                month.
+              </p>
+              <p>
+                <b>Note:</b> This number is set on the 1st of the month does not
+                change during the month.
+              </p>
+            </div>
+            <div class="notes-details">
+              <blockquote>
+                <h6>Numerator</h6>
+                <p>
+                  The number of <i>Overdue patients</i> on the 1st of the month,
+                  excluding patients that were previously contacted and marked
+                  'Remove from overdue list'.
+                </p>
+
+                <h6>Denominator</h6>
+                <p>
+                  <i>Patients under care</i> excluding dead patients and 12
+                  month lost to follow-up patients.
+                </p>
+              </blockquote>
+            </div>
+          </div>
+          <div class="notes-section">
+            <div class="notes-note" id="note-bp-overdue-contacted">
+              <h6>Overdue patients contacted</h6>
+              <p>
+                The percentage of overdue patients that were contacted during
+                the month.
+              </p>
+            </div>
+            <div class="notes-details">
+              <blockquote>
+                <h6>Numerator</h6>
+                <p>
+                  The number of unique <i>Overdue patients contacted</i> during
+                  the month.
+                </p>
+                <p>
+                  <b>Note:</b> This number includes patients that became overdue
+                  during the month and were contacted, these patients may not be
+                  counted in the denominator.
+                </p>
+                <h6>Denominator</h6>
+                <p>
+                  The number of <i>Overdue patients</i> on the 1st of the month,
+                  excluding patients that were previously contacted and marked
+                  'Remove from overdue list'.
+                </p>
+              </blockquote>
+            </div>
+          </div>
+          <div class="notes-section">
+            <div class="notes-note" id="note-bp-overdue-contacted-returned">
+              <h6>Overdue patients contacted that returned to care</h6>
+              <p>
+                The percentage of overdue patients that were contacted during
+                the month and returned to care within 15 days.
+              </p>
+            </div>
+            <div class="notes-details">
+              <blockquote>
+                <h6>Numerator</h6>
+                <p>
+                  The number of overdue patients that returned to care within 15
+                  days of their first contact.
+                </p>
+                <p>
+                  <b>Note:</b> For patients contacted multiple times during a
+                  month, 15 days begins from the date the patient was first
+                  contacted during a month.
+                </p>
+                <h6>Denominator</h6>
+                <p>
+                  The number of unique <i>Overdue patients contacted</i> during
+                  the month.
                 </p>
               </blockquote>
             </div>

--- a/js/charts.js
+++ b/js/charts.js
@@ -1416,9 +1416,9 @@ if (patientsProtectedCanvas) {
   createChart(patientsProtectedCanvas, patientsProtectedConfig);
 }
 
-// -- Overdue dashboard
+// -- Overdue
 
-// Overdue: At start of month
+// Overdue at start of month
 const overdueData = {
   labels: [
     "Mar-2023",
@@ -1455,34 +1455,19 @@ const overdueData = {
 
 const overdueConfig = baseLineChartConfig();
 overdueConfig.data = overdueData;
-// overdueConfig.options.scales.y.grid = { drawTicks: false };
-// overdueConfig.options.scales.y.ticks.display = false;
-overdueConfig.options.scales.y.ticks.count = 3;
-overdueConfig.options.scales.y.max = 100;
-// overdueConfig.options.scales.y.ticks.stepSize = 6052;
 
-overdueConfig.options.scales.yMonthlyRegistrations = {
-  display: false,
-  beginAtZero: true,
-  max: 1156,
+overdueConfig.options.scales.y.ticks.callback = (val) => {
+  return val + "%";
 };
-
-overdueConfig.options.plugins.tooltip.displayColors = true;
 overdueConfig.options.plugins.tooltip.callbacks = {
-  labelColor: function (context) {
-    return {
-      borderColor: "#fff",
-      backgroundColor: context.dataset.borderColor,
-      borderWidth: 1,
-    };
-  },
+  label: percentageLabel,
 };
 const overdueCanvas = document.getElementById("overdue");
 if (overdueCanvas) {
   createChart(overdueCanvas, overdueConfig);
 }
 
-// Overdue: Contacted
+// Overdue contacted
 const overdueContactedData = {
   labels: [
     "Mar-2023",
@@ -1524,31 +1509,20 @@ const overdueContactedData = {
 
 const overdueContactedConfig = baseLineChartConfig();
 overdueContactedConfig.data = overdueContactedData;
-overdueContactedConfig.options.scales.y.grid = { drawTicks: false };
-overdueContactedConfig.options.scales.y.max = 100;
 
-bpControlledConfig.options.scales.y.ticks.callback = (val) => {
+overdueContactedConfig.options.scales.y.ticks.callback = (val) => {
   return val + "%";
 };
-bpControlledConfig.options.plugins.tooltip.callbacks = {
+overdueContactedConfig.options.plugins.tooltip.callbacks = {
   label: percentageLabel,
 };
-overdueContactedConfig.options.plugins.tooltip.displayColors = true;
-overdueContactedConfig.options.plugins.tooltip.callbacks = {
-  labelColor: function (context) {
-    return {
-      borderColor: "#fff",
-      backgroundColor: context.dataset.borderColor,
-      borderWidth: 1,
-    };
-  },
-};
+
 const overdueContactedCanvas = document.getElementById("overdueContacted");
 if (overdueContactedCanvas) {
   createChart(overdueContactedCanvas, overdueContactedConfig);
 }
 
-// Overdue: Returned to care
+// Returned to care
 const overdueReturnedData = {
   labels: [
     "Mar-2023",
@@ -1594,27 +1568,10 @@ const overdueReturnedData = {
 const overdueReturnedConfig = baseLineChartConfig();
 overdueReturnedConfig.data = overdueReturnedData;
 
-overdueReturnedConfig.options.scales.yMonthlyRegistrations = {
-  display: false,
-  beginAtZero: true,
-  max: 1156,
-};
-
-overdueReturnedConfig.options.plugins.tooltip.displayColors = true;
-overdueReturnedConfig.options.plugins.tooltip.callbacks = {
-  labelColor: function (context) {
-    return {
-      borderColor: "#fff",
-      backgroundColor: context.dataset.borderColor,
-      borderWidth: 1,
-    };
-  },
-};
-
-bpControlledConfig.options.scales.y.ticks.callback = (val) => {
+overdueReturnedConfig.options.scales.y.ticks.callback = (val) => {
   return val + "%";
 };
-bpControlledConfig.options.plugins.tooltip.callbacks = {
+overdueReturnedConfig.options.plugins.tooltip.callbacks = {
   label: percentageLabel,
 };
 const overdueReturnedCanvas = document.getElementById("overdueReturned");

--- a/js/charts.js
+++ b/js/charts.js
@@ -1467,8 +1467,8 @@ if (overdueCanvas) {
   createChart(overdueCanvas, overdueConfig);
 }
 
-// Overdue contacted
-const overdueContactedData = {
+// Overdue called
+const overdueCalledData = {
   labels: [
     "Mar-2023",
     "Apr-2023",
@@ -1491,7 +1491,7 @@ const overdueContactedData = {
   ],
   datasets: [
     {
-      label: "Overdue patients contacted",
+      label: "Overdue patients called",
       data: [0, 5, 0, 0, 8, 12, 16, 22, 12, 10, 14, 25, 30, 22, 20, 21, 42, 10],
       borderColor: "#edbe00",
       backgroundColor: "#edbe0025",
@@ -1507,19 +1507,19 @@ const overdueContactedData = {
   ],
 };
 
-const overdueContactedConfig = baseLineChartConfig();
-overdueContactedConfig.data = overdueContactedData;
+const overdueCalledConfig = baseLineChartConfig();
+overdueCalledConfig.data = overdueCalledData;
 
-overdueContactedConfig.options.scales.y.ticks.callback = (val) => {
+overdueCalledConfig.options.scales.y.ticks.callback = (val) => {
   return val + "%";
 };
-overdueContactedConfig.options.plugins.tooltip.callbacks = {
+overdueCalledConfig.options.plugins.tooltip.callbacks = {
   label: percentageLabel,
 };
 
-const overdueContactedCanvas = document.getElementById("overdueContacted");
-if (overdueContactedCanvas) {
-  createChart(overdueContactedCanvas, overdueContactedConfig);
+const overdueCalledCanvas = document.getElementById("overdueCalled");
+if (overdueCalledCanvas) {
+  createChart(overdueCalledCanvas, overdueCalledConfig);
 }
 
 // Returned to care
@@ -1546,7 +1546,7 @@ const overdueReturnedData = {
   ],
   datasets: [
     {
-      label: "Overdue patients returned to care",
+      label: "Called overdue patients that returned to care",
       data: [
         0, 25, 0, 0, 10, 12, 22, 40, 24, 55, 60, 62, 44, 50, 33, 36, 58, 15,
       ],

--- a/js/charts.js
+++ b/js/charts.js
@@ -1415,3 +1415,209 @@ const patientsProtectedCanvas = document.getElementById("patientsprotected");
 if (patientsProtectedCanvas) {
   createChart(patientsProtectedCanvas, patientsProtectedConfig);
 }
+
+// -- Overdue dashboard
+
+// Overdue: At start of month
+const overdueData = {
+  labels: [
+    "Mar-2023",
+    "Apr-2023",
+    "May-2023",
+    "Jun-2023",
+    "Jul-2023",
+    "Aug-2023",
+    "Sep-2023",
+    "Oct-2023",
+    "Nov-2023",
+    "Dec-2023",
+    "Jan-2024",
+    "Feb-2024",
+    "Mar-2024",
+    "Apr-2024",
+    "May-2024",
+    "Jun-2024",
+    "Jul-2024",
+    "Aug-2024",
+  ],
+  datasets: [
+    {
+      label: "Overdue patients",
+      data: [
+        58, 54, 53, 52, 44, 39, 37, 40, 38, 37, 31, 28, 25, 28, 29, 30, 26, 25,
+      ],
+      borderColor: "#E77215",
+      backgroundColor: "#E7721525",
+      yAxisID: "y",
+    },
+  ],
+};
+
+const overdueConfig = baseLineChartConfig();
+overdueConfig.data = overdueData;
+// overdueConfig.options.scales.y.grid = { drawTicks: false };
+// overdueConfig.options.scales.y.ticks.display = false;
+overdueConfig.options.scales.y.ticks.count = 3;
+overdueConfig.options.scales.y.max = 100;
+// overdueConfig.options.scales.y.ticks.stepSize = 6052;
+
+overdueConfig.options.scales.yMonthlyRegistrations = {
+  display: false,
+  beginAtZero: true,
+  max: 1156,
+};
+
+overdueConfig.options.plugins.tooltip.displayColors = true;
+overdueConfig.options.plugins.tooltip.callbacks = {
+  labelColor: function (context) {
+    return {
+      borderColor: "#fff",
+      backgroundColor: context.dataset.borderColor,
+      borderWidth: 1,
+    };
+  },
+};
+const overdueCanvas = document.getElementById("overdue");
+if (overdueCanvas) {
+  createChart(overdueCanvas, overdueConfig);
+}
+
+// Overdue: Contacted
+const overdueContactedData = {
+  labels: [
+    "Mar-2023",
+    "Apr-2023",
+    "May-2023",
+    "Jun-2023",
+    "Jul-2023",
+    "Aug-2023",
+    "Sep-2023",
+    "Oct-2023",
+    "Nov-2023",
+    "Dec-2023",
+    "Jan-2024",
+    "Feb-2024",
+    "Mar-2024",
+    "Apr-2024",
+    "May-2024",
+    "Jun-2024",
+    "Jul-2024",
+    "Aug-2024",
+  ],
+  datasets: [
+    {
+      label: "Overdue patients contacted",
+      data: [0, 5, 0, 0, 8, 12, 16, 22, 12, 10, 14, 25, 30, 22, 20, 21, 42, 10],
+      borderColor: "#edbe00",
+      backgroundColor: "#edbe0025",
+      yAxisID: "y",
+      segment: {
+        borderDash: (ctx) =>
+          dynamicChartSegementDashed(
+            ctx,
+            18 // number of data elements
+          ),
+      },
+    },
+  ],
+};
+
+const overdueContactedConfig = baseLineChartConfig();
+overdueContactedConfig.data = overdueContactedData;
+overdueContactedConfig.options.scales.y.grid = { drawTicks: false };
+overdueContactedConfig.options.scales.y.max = 100;
+
+bpControlledConfig.options.scales.y.ticks.callback = (val) => {
+  return val + "%";
+};
+bpControlledConfig.options.plugins.tooltip.callbacks = {
+  label: percentageLabel,
+};
+overdueContactedConfig.options.plugins.tooltip.displayColors = true;
+overdueContactedConfig.options.plugins.tooltip.callbacks = {
+  labelColor: function (context) {
+    return {
+      borderColor: "#fff",
+      backgroundColor: context.dataset.borderColor,
+      borderWidth: 1,
+    };
+  },
+};
+const overdueContactedCanvas = document.getElementById("overdueContacted");
+if (overdueContactedCanvas) {
+  createChart(overdueContactedCanvas, overdueContactedConfig);
+}
+
+// Overdue: Returned to care
+const overdueReturnedData = {
+  labels: [
+    "Mar-2023",
+    "Apr-2023",
+    "May-2023",
+    "Jun-2023",
+    "Jul-2023",
+    "Aug-2023",
+    "Sep-2023",
+    "Oct-2023",
+    "Nov-2023",
+    "Dec-2023",
+    "Jan-2024",
+    "Feb-2024",
+    "Mar-2024",
+    "Apr-2024",
+    "May-2024",
+    "Jun-2024",
+    "Jul-2024",
+    "Aug-2024",
+  ],
+  datasets: [
+    {
+      label: "Overdue patients returned to care",
+      data: [
+        0, 25, 0, 0, 10, 12, 22, 40, 24, 55, 60, 62, 44, 50, 33, 36, 58, 15,
+      ],
+      borderColor: "#5300e0",
+      backgroundColor: "#5300e010",
+      yAxisID: "y",
+      segment: {
+        borderDash: (ctx) =>
+          dynamicChartSegementDashed(
+            ctx,
+            18, // number of data elements,
+            2
+          ),
+      },
+    },
+  ],
+};
+
+const overdueReturnedConfig = baseLineChartConfig();
+overdueReturnedConfig.data = overdueReturnedData;
+
+overdueReturnedConfig.options.scales.yMonthlyRegistrations = {
+  display: false,
+  beginAtZero: true,
+  max: 1156,
+};
+
+overdueReturnedConfig.options.plugins.tooltip.displayColors = true;
+overdueReturnedConfig.options.plugins.tooltip.callbacks = {
+  labelColor: function (context) {
+    return {
+      borderColor: "#fff",
+      backgroundColor: context.dataset.borderColor,
+      borderWidth: 1,
+    };
+  },
+};
+
+bpControlledConfig.options.scales.y.ticks.callback = (val) => {
+  return val + "%";
+};
+bpControlledConfig.options.plugins.tooltip.callbacks = {
+  label: percentageLabel,
+};
+const overdueReturnedCanvas = document.getElementById("overdueReturned");
+if (overdueReturnedCanvas) {
+  createChart(overdueReturnedCanvas, overdueReturnedConfig);
+}


### PR DESCRIPTION
Aim: Adding overdue based reports to the hypertension dashboard

What's included:
- New report: Overdue patients
- New report: Overdue patients contacted
- New report: Overdue patients contacted that returned to care

MInor:
- Cards have less margin in mobile view to give more room for content